### PR TITLE
[codex] Add IMM32 composition caret support

### DIFF
--- a/ResoniteBetterIMESupport.Engine/EngineIMEPatch.cs
+++ b/ResoniteBetterIMESupport.Engine/EngineIMEPatch.cs
@@ -12,6 +12,9 @@ static class EngineIMEPatch
     static Messenger? _messenger;
     static bool _stringChanged;
     static bool _isTypingUnsettled;
+    static int _compositionStart = -1;
+    static int _compositionLength;
+    static int _compositionVisualCaret = -1;
     public static bool IsTypingUnsettled => _isTypingUnsettled;
 
     public static string DebugState => BuildDebugState();
@@ -42,6 +45,7 @@ static class EngineIMEPatch
         _editingText = text;
         _stringChanged = false;
         _isTypingUnsettled = false;
+        ClearCompositionRange();
         var textValue = text.Text ?? string.Empty;
         DebugLog($"SetEditingText: textLength={textValue.Length}, caret={text.CaretPosition}, selectionStart={text.SelectionStart}");
     }
@@ -53,6 +57,7 @@ static class EngineIMEPatch
         _editingText = null;
         _stringChanged = false;
         _isTypingUnsettled = false;
+        ClearCompositionRange();
     }
 
     public static bool ConsumeStringChanged()
@@ -97,30 +102,52 @@ static class EngineIMEPatch
 
         DebugLog($"ApplyMessage begin: {message}, {DebugState}");
 
-        ApplyComposition(message.Composition);
+        ApplyComposition(message.Composition, message.CompositionCursor, message.HasCommittedResult);
     }
 
-    static void ApplyComposition(string composition)
+    static void ApplyComposition(string composition, int compositionCursor, bool hasCommittedResult)
     {
         if (_editingText == null)
             return;
 
-        if (HasSelection)
+        if (hasCommittedResult && HasCompositionRange)
+        {
+            DeleteCompositionRange();
+            _isTypingUnsettled = false;
+            if (composition.Length == 0)
+            {
+                HasSelection = false;
+                DebugLog($"ApplyComposition cleared composition after committed result: {DebugState}");
+                return;
+            }
+
+            DebugLog($"ApplyComposition deferred next composition after committed result: nextLength={composition.Length}, {DebugState}");
+            return;
+        }
+
+        if (HasCompositionRange)
+            DeleteCompositionRange();
+        else if (HasSelection)
             DeleteSelection();
 
         if (composition.Length == 0)
         {
+            ClearCompositionRange();
             HasSelection = false;
             _isTypingUnsettled = false;
             DebugLog($"ApplyComposition cleared composition: {DebugState}");
             return;
         }
 
-        SelectionStart = CaretPosition;
+        var compositionStart = CaretPosition;
         InsertText(composition);
+        _compositionStart = compositionStart;
+        _compositionLength = composition.Length;
+        _compositionVisualCaret = ToTextCaretPosition(compositionStart, composition.Length, compositionCursor);
+        HasSelection = false;
         _isTypingUnsettled = true;
         _stringChanged = true;
-        DebugLog($"ApplyComposition replaced composition: {DebugState}");
+        DebugLog($"ApplyComposition replaced composition: visualCaret={_compositionVisualCaret}, {DebugState}");
     }
 
     static void InsertText(string value)
@@ -143,6 +170,81 @@ static class EngineIMEPatch
         _editingText.Text = _editingText.Text.Remove(start, SelectionLength);
         HasSelection = false;
         CaretPosition = start;
+    }
+
+    static void DeleteCompositionRange()
+    {
+        if (_editingText == null || !HasCompositionRange)
+            return;
+
+        var start = MathX.Clamp(_compositionStart, 0, _editingText.Text.Length);
+        var length = MathX.Min(_compositionLength, _editingText.Text.Length - start);
+        if (length > 0)
+            _editingText.Text = _editingText.Text.Remove(start, length);
+
+        ClearCompositionRange();
+        HasSelection = false;
+        CaretPosition = start;
+    }
+
+    static int NormalizeCompositionCursor(int compositionCursor, int compositionLength) =>
+        compositionCursor < 0 ? compositionLength : ClampInclusive(compositionCursor, 0, compositionLength);
+
+    static int ToTextCaretPosition(int compositionStart, int compositionLength, int compositionCursor)
+    {
+        var normalizedCursor = NormalizeCompositionCursor(compositionCursor, compositionLength);
+        return compositionStart + normalizedCursor;
+    }
+
+    static int ClampInclusive(int value, int min, int max)
+    {
+        if (value < min)
+            return min;
+
+        return value > max ? max : value;
+    }
+
+    static bool HasCompositionRange => _compositionStart >= 0 && _compositionLength > 0;
+
+    static void ClearCompositionRange()
+    {
+        _compositionStart = -1;
+        _compositionLength = 0;
+        _compositionVisualCaret = -1;
+    }
+
+    public static bool TryGetCompositionVisualRange(
+        string text,
+        out int compositionStart,
+        out int compositionLength)
+    {
+        compositionStart = -1;
+        compositionLength = 0;
+
+        if (_editingText == null
+            || !HasCompositionRange
+            || !string.Equals(_editingText.Text, text, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        compositionStart = _compositionStart;
+        compositionLength = _compositionLength;
+        return true;
+    }
+
+    public static bool TryGetCompositionVisualCaret(string text, out int visualCaret)
+    {
+        visualCaret = -1;
+        if (_editingText == null
+            || !HasCompositionRange
+            || !string.Equals(_editingText.Text, text, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        visualCaret = ClampInclusive(_compositionVisualCaret, _compositionStart, _compositionStart + _compositionLength);
+        return true;
     }
 
     static bool HasSelection
@@ -208,7 +310,7 @@ static class EngineIMEPatch
         if (_editingText == null)
             return "state={editingText=null}";
 
-        return $"state={{textLength={_editingText.Text.Length}, caret={CaretPosition}, selectionStart={SelectionStart}, selectionLength={SelectionLength}, typingUnsettled={_isTypingUnsettled}, text=\"{EscapeForLog(_editingText.Text)}\"}}";
+        return $"state={{textLength={_editingText.Text.Length}, caret={CaretPosition}, selectionStart={SelectionStart}, selectionLength={SelectionLength}, compositionStart={_compositionStart}, compositionLength={_compositionLength}, compositionVisualCaret={_compositionVisualCaret}, typingUnsettled={_isTypingUnsettled}, text=\"{EscapeForLog(_editingText.Text)}\"}}";
     }
 
     static string EscapeForLog(string value) =>

--- a/ResoniteBetterIMESupport.Engine/EngineIMEPatch.cs
+++ b/ResoniteBetterIMESupport.Engine/EngineIMEPatch.cs
@@ -42,6 +42,9 @@ static class EngineIMEPatch
             return;
         }
 
+        if (_editingText != null && !ReferenceEquals(_editingText, text))
+            CommitVisibleComposition("SetEditingText switched target");
+
         _editingText = text;
         _stringChanged = false;
         _isTypingUnsettled = false;
@@ -53,6 +56,8 @@ static class EngineIMEPatch
     public static void ClearEditingText()
     {
         DebugLog($"ClearEditingText before: {DebugState}");
+
+        CommitVisibleComposition("ClearEditingText");
 
         _editingText = null;
         _stringChanged = false;
@@ -112,16 +117,7 @@ static class EngineIMEPatch
 
         if (hasCommittedResult && HasCompositionRange)
         {
-            DeleteCompositionRange();
-            _isTypingUnsettled = false;
-            if (composition.Length == 0)
-            {
-                HasSelection = false;
-                DebugLog($"ApplyComposition cleared composition after committed result: {DebugState}");
-                return;
-            }
-
-            DebugLog($"ApplyComposition deferred next composition after committed result: nextLength={composition.Length}, {DebugState}");
+            CommitVisibleComposition("ApplyComposition committed result");
             return;
         }
 
@@ -155,9 +151,10 @@ static class EngineIMEPatch
         if (_editingText == null || value.Length == 0)
             return;
 
-        _editingText.Text = _editingText.Text.Substring(0, CaretPosition)
+        var text = TextValue;
+        _editingText.Text = text.Substring(0, CaretPosition)
             + value
-            + _editingText.Text.Substring(CaretPosition, _editingText.Text.Length - CaretPosition);
+            + text.Substring(CaretPosition, text.Length - CaretPosition);
         CaretPosition += value.Length;
     }
 
@@ -167,7 +164,7 @@ static class EngineIMEPatch
             return;
 
         var start = MathX.Min(SelectionStart, CaretPosition);
-        _editingText.Text = _editingText.Text.Remove(start, SelectionLength);
+        _editingText.Text = TextValue.Remove(start, SelectionLength);
         HasSelection = false;
         CaretPosition = start;
     }
@@ -177,14 +174,29 @@ static class EngineIMEPatch
         if (_editingText == null || !HasCompositionRange)
             return;
 
-        var start = MathX.Clamp(_compositionStart, 0, _editingText.Text.Length);
-        var length = MathX.Min(_compositionLength, _editingText.Text.Length - start);
+        var text = TextValue;
+        var start = MathX.Clamp(_compositionStart, 0, text.Length);
+        var length = MathX.Min(_compositionLength, text.Length - start);
         if (length > 0)
-            _editingText.Text = _editingText.Text.Remove(start, length);
+            _editingText.Text = text.Remove(start, length);
 
         ClearCompositionRange();
         HasSelection = false;
         CaretPosition = start;
+    }
+
+    static void CommitVisibleComposition(string source)
+    {
+        if (!HasCompositionRange)
+            return;
+
+        var caretPosition = _compositionStart + _compositionLength;
+        ClearCompositionRange();
+        HasSelection = false;
+        CaretPosition = caretPosition;
+        _isTypingUnsettled = false;
+        _stringChanged = true;
+        DebugLog($"{source} committed visible composition: {DebugState}");
     }
 
     static int NormalizeCompositionCursor(int compositionCursor, int compositionLength) =>
@@ -223,7 +235,7 @@ static class EngineIMEPatch
 
         if (_editingText == null
             || !HasCompositionRange
-            || !string.Equals(_editingText.Text, text, StringComparison.Ordinal))
+            || !string.Equals(TextValue, text, StringComparison.Ordinal))
         {
             return false;
         }
@@ -238,7 +250,7 @@ static class EngineIMEPatch
         visualCaret = -1;
         if (_editingText == null
             || !HasCompositionRange
-            || !string.Equals(_editingText.Text, text, StringComparison.Ordinal))
+            || !string.Equals(TextValue, text, StringComparison.Ordinal))
         {
             return false;
         }
@@ -266,17 +278,18 @@ static class EngineIMEPatch
             if (_editingText == null)
                 return -1;
 
-            return MathX.Clamp(_editingText.CaretPosition, -1, _editingText.Text.Length + 1);
+            return MathX.Clamp(_editingText.CaretPosition, -1, TextValue.Length + 1);
         }
         set
         {
             if (_editingText == null)
                 return;
 
-            value = MathX.Clamp(value, 0, _editingText.Text.Length + 1);
+            var text = TextValue;
+            value = MathX.Clamp(value, 0, text.Length + 1);
             if (value > 0
-                && value < _editingText.Text.Length
-                && char.GetUnicodeCategory(_editingText.Text, value) == System.Globalization.UnicodeCategory.Surrogate)
+                && value < text.Length
+                && char.GetUnicodeCategory(text, value) == System.Globalization.UnicodeCategory.Surrogate)
             {
                 value += MathX.Sign(value - _editingText.CaretPosition);
             }
@@ -292,25 +305,28 @@ static class EngineIMEPatch
             if (_editingText == null)
                 return -1;
 
-            return MathX.Clamp(_editingText.SelectionStart, -1, _editingText.Text.Length);
+            return MathX.Clamp(_editingText.SelectionStart, -1, TextValue.Length);
         }
         set
         {
             if (_editingText == null)
                 return;
 
-            _editingText.SelectionStart = MathX.Clamp(value, 0, _editingText.Text.Length + 1);
+            _editingText.SelectionStart = MathX.Clamp(value, 0, TextValue.Length + 1);
         }
     }
 
     static int SelectionLength => !HasSelection ? 0 : MathX.Abs(CaretPosition - SelectionStart);
+
+    static string TextValue => _editingText?.Text ?? string.Empty;
 
     static string BuildDebugState()
     {
         if (_editingText == null)
             return "state={editingText=null}";
 
-        return $"state={{textLength={_editingText.Text.Length}, caret={CaretPosition}, selectionStart={SelectionStart}, selectionLength={SelectionLength}, compositionStart={_compositionStart}, compositionLength={_compositionLength}, compositionVisualCaret={_compositionVisualCaret}, typingUnsettled={_isTypingUnsettled}, text=\"{EscapeForLog(_editingText.Text)}\"}}";
+        var text = TextValue;
+        return $"state={{textLength={text.Length}, caret={CaretPosition}, selectionStart={SelectionStart}, selectionLength={SelectionLength}, compositionStart={_compositionStart}, compositionLength={_compositionLength}, compositionVisualCaret={_compositionVisualCaret}, typingUnsettled={_isTypingUnsettled}, text=\"{EscapeForLog(text)}\"}}";
     }
 
     static string EscapeForLog(string value) =>

--- a/ResoniteBetterIMESupport.Engine/Patches/GlyphAtlasMeshGeneratorPatch.cs
+++ b/ResoniteBetterIMESupport.Engine/Patches/GlyphAtlasMeshGeneratorPatch.cs
@@ -1,0 +1,174 @@
+using Elements.Assets;
+using Elements.Core;
+using HarmonyLib;
+
+namespace ResoniteBetterIMESupport.Engine.Patches;
+
+[HarmonyPatch(typeof(GlyphAtlasMeshGenerator), nameof(GlyphAtlasMeshGenerator.Generate))]
+static class GlyphAtlasMeshGeneratorPatch
+{
+    readonly struct LineSegment
+    {
+        public readonly StringLine Line;
+        public readonly int EndGlyphIndex;
+        public readonly RenderGlyph StartGlyph;
+        public readonly RenderGlyph EndGlyph;
+
+        public LineSegment(StringLine line, int endGlyphIndex, RenderGlyph startGlyph, RenderGlyph endGlyph)
+        {
+            Line = line;
+            EndGlyphIndex = endGlyphIndex;
+            StartGlyph = startGlyph;
+            EndGlyph = endGlyph;
+        }
+    }
+
+    static void Prefix(StringRenderTree renderTree, ref TextEditingVisuals textEditVisuals)
+    {
+        if (EngineIMEPatch.TryGetCompositionVisualCaret(renderTree.String, out var visualCaret))
+            textEditVisuals.caretPosition = visualCaret;
+    }
+
+    static void Postfix(
+        StringRenderTree renderTree,
+        float2 offset,
+        MeshX meshx,
+        AtlasSubmeshMapper submeshMapper,
+        TextEditingVisuals textEditVisuals,
+        ref bool usesAuxiliarySubmesh)
+    {
+        if (!EngineIMEPatch.TryGetCompositionVisualRange(
+                renderTree.String,
+                out var compositionStart,
+                out var compositionLength))
+        {
+            return;
+        }
+
+        var compositionEnd = compositionStart + compositionLength;
+        var startGlyph = MatchStringPositionToGlyph(renderTree, compositionStart);
+        var endGlyph = MatchStringPositionToGlyph(renderTree, compositionEnd);
+        if (startGlyph < 0 || endGlyph <= startGlyph || renderTree.GlyphLayoutLength <= 0)
+            return;
+
+        var triangleSubmesh = submeshMapper(default);
+        var lineSegments = Pool.BorrowList<LineSegment>();
+        try
+        {
+            ExtractLineSegments(renderTree, startGlyph, endGlyph - startGlyph, lineSegments);
+            var color = textEditVisuals.selectionColor.ToProfile(meshx.Profile);
+            foreach (var segment in lineSegments)
+                Underline(meshx, triangleSubmesh, renderTree, segment, color, offset);
+        }
+        finally
+        {
+            Pool.Return(ref lineSegments);
+        }
+
+        usesAuxiliarySubmesh = true;
+    }
+
+    static int MatchStringPositionToGlyph(StringRenderTree renderTree, int stringPosition)
+    {
+        if (stringPosition < 0)
+            return stringPosition;
+
+        for (var i = 0; i < renderTree.GlyphLayoutLength; i++)
+        {
+            var glyph = renderTree.GetRenderGlyph(i);
+            if (glyph.stringIndex == stringPosition)
+                return i;
+
+            if (glyph.stringIndex > stringPosition)
+                return i - 1;
+        }
+
+        return renderTree.GlyphLayoutLength;
+    }
+
+    static void ExtractLineSegments(StringRenderTree renderTree, int startIndex, int length, List<LineSegment> lineSegments)
+    {
+        var lineIndex = -1;
+        var startGlyph = default(RenderGlyph);
+        var endGlyph = default(RenderGlyph);
+
+        for (var i = 0; i < length + 1; i++)
+        {
+            var isEnd = i == length;
+            var glyphIndex = startIndex + i;
+            var glyph = default(RenderGlyph);
+            if (!isEnd)
+                glyph = renderTree.GetRenderGlyph(MathX.Min(glyphIndex, renderTree.GlyphLayoutLength - 1));
+
+            if (glyph.line != lineIndex || isEnd)
+            {
+                if (lineIndex >= 0)
+                    lineSegments.Add(new LineSegment(renderTree.GetLine(lineIndex), glyphIndex, startGlyph, endGlyph));
+
+                if (!isEnd)
+                {
+                    startGlyph = glyph;
+                    lineIndex = glyph.line;
+                }
+            }
+
+            endGlyph = glyph;
+        }
+    }
+
+    static void Underline(
+        MeshX mesh,
+        TriangleSubmesh submesh,
+        StringRenderTree renderTree,
+        LineSegment segment,
+        color color,
+        float2 offset)
+    {
+        var height = MathX.Max(segment.Line.ActualHeight, segment.Line.LineHeight);
+        var y = 0f - segment.Line.Position.y - 0.1f * height;
+        var startPoint = new float2(segment.StartGlyph.rect.xmin + segment.Line.Position.x, y);
+        var endPoint = new float2(segment.EndGlyph.pen.x + segment.Line.Position.x, y);
+        var nextGlyphIndex = segment.EndGlyphIndex + 1;
+        if (nextGlyphIndex < renderTree.GlyphLayoutLength)
+        {
+            var nextGlyph = renderTree.GetRenderGlyph(nextGlyphIndex);
+            if (nextGlyph.line == segment.EndGlyph.line)
+                endPoint = new float2(nextGlyph.rect.xmin + segment.Line.Position.x, endPoint.y);
+        }
+
+        InsertLine(mesh, submesh, startPoint, endPoint, color, 0.075f * height, offset);
+    }
+
+    static void InsertLine(
+        MeshX mesh,
+        TriangleSubmesh submesh,
+        float2 startPoint,
+        float2 endPoint,
+        color color,
+        float thickness,
+        float2 offset)
+    {
+        mesh.IncreaseVertexCount(4);
+        var index = mesh.VertexCount - 4;
+        var y = thickness * 0.5f;
+
+        mesh.RawPositions[index] = startPoint - new float2(0f, y) + offset;
+        mesh.RawPositions[index + 1] = startPoint + new float2(0f, y) + offset;
+        mesh.RawPositions[index + 2] = endPoint + new float2(0f, y) + offset;
+        mesh.RawPositions[index + 3] = endPoint - new float2(0f, y) + offset;
+
+        mesh.RawUV0s[index] = new float2(0f, 0f);
+        mesh.RawUV0s[index + 1] = new float2(0f, 1f);
+        mesh.RawUV0s[index + 2] = new float2(1f, 1f);
+        mesh.RawUV0s[index + 3] = new float2(1f);
+
+        for (var i = 0; i < 4; i++)
+        {
+            var vertex = index + i;
+            mesh.RawColors[vertex] = color;
+            mesh.RawNormals[vertex] = new float3(0f, 0f, 0f);
+        }
+
+        submesh.AddQuadAsTriangles(index, index + 1, index + 2, index + 3);
+    }
+}

--- a/ResoniteBetterIMESupport.Renderer/KeyboardDriverIMEPatch.cs
+++ b/ResoniteBetterIMESupport.Renderer/KeyboardDriverIMEPatch.cs
@@ -83,17 +83,28 @@ static class KeyboardDriverIMEPatch
         ClearComposition(state);
     }
 
+    public static bool ShouldAllowTextInput(object driver, char value)
+    {
+        var state = GetState(driver);
+        if (state.ImeComposition.Length == 0)
+            return true;
+
+        DebugLog($"Suppressed text input during composition: char=0x{(int)value:X4}, composition=\"{EscapeForLog(state.ImeComposition)}\"");
+        return false;
+    }
+
     static void OnIMECompositionChange(object driver, IMECompositionString composition)
     {
         var compositionText = composition.ToString();
         var state = GetState(driver);
         var compositionCursor = -1;
         var hasCommittedResult = false;
-        if (WindowsImeContextReader.TryGetCursorPosition(compositionText, out var windowsCursor, out var windowsHasCommittedResult, out var windowsImeDiagnostic))
+        if (WindowsImeContextReader.TryGetCursorPosition(compositionText, out var windowsCursor, out var windowsHasCommittedResult, out _, out var windowsImeDiagnostic))
         {
             compositionCursor = windowsCursor;
-            hasCommittedResult = windowsHasCommittedResult;
         }
+
+        hasCommittedResult = windowsHasCommittedResult;
 
         DebugLog($"OnIMECompositionChange: composition=\"{EscapeForLog(compositionText)}\", previous=\"{EscapeForLog(state.ImeComposition)}\", windowsIme={windowsImeDiagnostic}");
 

--- a/ResoniteBetterIMESupport.Renderer/KeyboardDriverIMEPatch.cs
+++ b/ResoniteBetterIMESupport.Renderer/KeyboardDriverIMEPatch.cs
@@ -77,7 +77,7 @@ static class KeyboardDriverIMEPatch
         }
 
         DebugLog($"Keyboard input became inactive. Canceling composition=\"{EscapeForLog(state.ImeComposition)}\"");
-        if (!TrySendComposition(string.Empty))
+        if (!TrySendComposition(string.Empty, -1))
             DebugLog("Composition clear send failed.");
 
         ClearComposition(state);
@@ -87,9 +87,17 @@ static class KeyboardDriverIMEPatch
     {
         var compositionText = composition.ToString();
         var state = GetState(driver);
-        DebugLog($"OnIMECompositionChange: composition=\"{EscapeForLog(compositionText)}\", previous=\"{EscapeForLog(state.ImeComposition)}\"");
+        var compositionCursor = -1;
+        var hasCommittedResult = false;
+        if (WindowsImeContextReader.TryGetCursorPosition(compositionText, out var windowsCursor, out var windowsHasCommittedResult, out var windowsImeDiagnostic))
+        {
+            compositionCursor = windowsCursor;
+            hasCommittedResult = windowsHasCommittedResult;
+        }
 
-        if (!TrySendComposition(compositionText))
+        DebugLog($"OnIMECompositionChange: composition=\"{EscapeForLog(compositionText)}\", previous=\"{EscapeForLog(state.ImeComposition)}\", windowsIme={windowsImeDiagnostic}");
+
+        if (!TrySendComposition(compositionText, compositionCursor, hasCommittedResult))
         {
             DebugLog("Composition update send failed.");
             return;
@@ -100,14 +108,16 @@ static class KeyboardDriverIMEPatch
             ClearComposition(state);
     }
 
-    static bool TrySendComposition(string composition)
+    static bool TrySendComposition(string composition, int compositionCursor, bool hasCommittedResult = false)
     {
         try
         {
             InitializeMessaging();
             _messenger!.SendObject(ImeInterprocessChannel.MessageId, new ImeInterprocessMessage
             {
-                Composition = composition
+                Composition = composition,
+                CompositionCursor = compositionCursor,
+                HasCommittedResult = hasCommittedResult
             });
             return true;
         }

--- a/ResoniteBetterIMESupport.Renderer/Patches/KeyboardDriverPatches.cs
+++ b/ResoniteBetterIMESupport.Renderer/Patches/KeyboardDriverPatches.cs
@@ -13,6 +13,14 @@ static class KeyboardDriverStartPatch
 }
 
 [HarmonyPatch]
+static class KeyboardDriverTextInputPatch
+{
+    static MethodBase TargetMethod() => AccessTools.Method(KeyboardDriverIMEPatch.KeyboardDriverType, "Current_onTextInput");
+
+    static bool Prefix(object __instance, char obj) => KeyboardDriverIMEPatch.ShouldAllowTextInput(__instance, obj);
+}
+
+[HarmonyPatch]
 static class KeyboardDriverHandleOutputStatePatch
 {
     static MethodBase TargetMethod() => AccessTools.Method(KeyboardDriverIMEPatch.KeyboardDriverType, "HandleOutputState");

--- a/ResoniteBetterIMESupport.Renderer/WindowsImeContextReader.cs
+++ b/ResoniteBetterIMESupport.Renderer/WindowsImeContextReader.cs
@@ -1,0 +1,154 @@
+using System.Runtime.InteropServices;
+
+namespace ResoniteBetterIMESupport.Renderer;
+
+static class WindowsImeContextReader
+{
+    const int GCS_COMPSTR = 0x0008;
+    const int GCS_CURSORPOS = 0x0080;
+    const int GCS_RESULTSTR = 0x0800;
+    const int IMM_ERROR_NODATA = -1;
+    const int IMM_ERROR_GENERAL = -2;
+
+    public static bool TryGetCursorPosition(string unityComposition, out int cursorPosition, out bool hasCommittedResult, out string diagnostic)
+    {
+        cursorPosition = -1;
+        hasCommittedResult = false;
+        diagnostic = "unavailable";
+
+        if (!IsWindows())
+        {
+            diagnostic = "not-windows";
+            return false;
+        }
+
+        try
+        {
+            return TryGetCursorPositionFromImm32(unityComposition, out cursorPosition, out hasCommittedResult, out diagnostic);
+        }
+        catch (Exception ex)
+        {
+            cursorPosition = -1;
+            hasCommittedResult = false;
+            diagnostic = $"native-ime-unavailable, exception={ex.GetType().Name}, message=\"{EscapeForLog(ex.Message)}\"";
+            return false;
+        }
+    }
+
+    static bool TryGetCursorPositionFromImm32(string unityComposition, out int cursorPosition, out bool hasCommittedResult, out string diagnostic)
+    {
+        cursorPosition = -1;
+        hasCommittedResult = false;
+        diagnostic = "unavailable";
+
+        var hwnd = GetActiveWindow();
+        var hwndSource = "active";
+        if (hwnd == IntPtr.Zero)
+        {
+            hwnd = GetForegroundWindow();
+            hwndSource = "foreground";
+        }
+
+        if (hwnd == IntPtr.Zero)
+        {
+            diagnostic = "no-hwnd";
+            return false;
+        }
+
+        var himc = ImmGetContext(hwnd);
+        if (himc == IntPtr.Zero)
+        {
+            diagnostic = $"no-himc, hwndSource={hwndSource}, hwnd=0x{hwnd.ToInt64():X}";
+            return false;
+        }
+
+        try
+        {
+            var immComposition = TryGetCompositionString(himc, GCS_COMPSTR, out var stringStatus);
+            var immResult = TryGetCompositionString(himc, GCS_RESULTSTR, out var resultStatus);
+            hasCommittedResult = !string.IsNullOrEmpty(immResult);
+            var rawCursor = ImmGetCompositionStringW(himc, GCS_CURSORPOS, IntPtr.Zero, 0);
+            if (rawCursor == IMM_ERROR_NODATA || rawCursor == IMM_ERROR_GENERAL)
+            {
+                diagnostic = $"cursor={FormatImmValue(rawCursor)}, compStringStatus={FormatImmValue(stringStatus)}, compString=\"{EscapeForLog(immComposition ?? "<null>")}\", resultStatus={FormatImmValue(resultStatus)}, hasResult={hasCommittedResult}";
+                return false;
+            }
+
+            var normalizedCursor = rawCursor & 0xFFFF;
+            var compositionMatches = immComposition == null || immComposition == unityComposition;
+            diagnostic = $"cursor={normalizedCursor}, compStringStatus={FormatImmValue(stringStatus)}, compString=\"{EscapeForLog(immComposition ?? "<null>")}\", resultStatus={FormatImmValue(resultStatus)}, hasResult={hasCommittedResult}, unityMatch={compositionMatches}";
+            if (!compositionMatches)
+                return false;
+
+            cursorPosition = normalizedCursor;
+            return true;
+        }
+        finally
+        {
+            TryReleaseContext(hwnd, himc);
+        }
+    }
+
+    static void TryReleaseContext(IntPtr hwnd, IntPtr himc)
+    {
+        try
+        {
+            ImmReleaseContext(hwnd, himc);
+        }
+        catch
+        {
+        }
+    }
+
+    static string? TryGetCompositionString(IntPtr himc, int index, out int status)
+    {
+        var byteLength = ImmGetCompositionStringW(himc, index, IntPtr.Zero, 0);
+        status = byteLength;
+        if (byteLength <= 0)
+            return byteLength == 0 ? string.Empty : null;
+
+        var buffer = Marshal.AllocHGlobal(byteLength);
+        try
+        {
+            var copied = ImmGetCompositionStringW(himc, index, buffer, byteLength);
+            status = copied;
+            return copied <= 0 ? copied == 0 ? string.Empty : null : Marshal.PtrToStringUni(buffer, copied / 2);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(buffer);
+        }
+    }
+
+    static bool IsWindows() =>
+        Environment.OSVersion.Platform == PlatformID.Win32NT
+        || Environment.OSVersion.Platform == PlatformID.Win32S
+        || Environment.OSVersion.Platform == PlatformID.Win32Windows
+        || Environment.OSVersion.Platform == PlatformID.WinCE;
+
+    static string FormatImmValue(int value) =>
+        value switch
+        {
+            IMM_ERROR_NODATA => "IMM_ERROR_NODATA",
+            IMM_ERROR_GENERAL => "IMM_ERROR_GENERAL",
+            _ => value.ToString()
+        };
+
+    static string EscapeForLog(string value) =>
+        value.Replace("\\", "\\\\").Replace("\r", "\\r").Replace("\n", "\\n").Replace("\t", "\\t");
+
+    [DllImport("user32.dll")]
+    static extern IntPtr GetActiveWindow();
+
+    [DllImport("user32.dll")]
+    static extern IntPtr GetForegroundWindow();
+
+    [DllImport("imm32.dll")]
+    static extern IntPtr ImmGetContext(IntPtr hWnd);
+
+    [DllImport("imm32.dll")]
+    static extern bool ImmReleaseContext(IntPtr hWnd, IntPtr hIMC);
+
+    [DllImport("imm32.dll", CharSet = CharSet.Unicode)]
+    static extern int ImmGetCompositionStringW(IntPtr hIMC, int dwIndex, IntPtr lpBuf, int dwBufLen);
+}

--- a/ResoniteBetterIMESupport.Renderer/WindowsImeContextReader.cs
+++ b/ResoniteBetterIMESupport.Renderer/WindowsImeContextReader.cs
@@ -10,10 +10,11 @@ static class WindowsImeContextReader
     const int IMM_ERROR_NODATA = -1;
     const int IMM_ERROR_GENERAL = -2;
 
-    public static bool TryGetCursorPosition(string unityComposition, out int cursorPosition, out bool hasCommittedResult, out string diagnostic)
+    public static bool TryGetCursorPosition(string unityComposition, out int cursorPosition, out bool hasCommittedResult, out string committedResult, out string diagnostic)
     {
         cursorPosition = -1;
         hasCommittedResult = false;
+        committedResult = string.Empty;
         diagnostic = "unavailable";
 
         if (!IsWindows())
@@ -24,21 +25,23 @@ static class WindowsImeContextReader
 
         try
         {
-            return TryGetCursorPositionFromImm32(unityComposition, out cursorPosition, out hasCommittedResult, out diagnostic);
+            return TryGetCursorPositionFromImm32(unityComposition, out cursorPosition, out hasCommittedResult, out committedResult, out diagnostic);
         }
         catch (Exception ex)
         {
             cursorPosition = -1;
             hasCommittedResult = false;
+            committedResult = string.Empty;
             diagnostic = $"native-ime-unavailable, exception={ex.GetType().Name}, message=\"{EscapeForLog(ex.Message)}\"";
             return false;
         }
     }
 
-    static bool TryGetCursorPositionFromImm32(string unityComposition, out int cursorPosition, out bool hasCommittedResult, out string diagnostic)
+    static bool TryGetCursorPositionFromImm32(string unityComposition, out int cursorPosition, out bool hasCommittedResult, out string committedResult, out string diagnostic)
     {
         cursorPosition = -1;
         hasCommittedResult = false;
+        committedResult = string.Empty;
         diagnostic = "unavailable";
 
         var hwnd = GetActiveWindow();
@@ -66,17 +69,18 @@ static class WindowsImeContextReader
         {
             var immComposition = TryGetCompositionString(himc, GCS_COMPSTR, out var stringStatus);
             var immResult = TryGetCompositionString(himc, GCS_RESULTSTR, out var resultStatus);
-            hasCommittedResult = !string.IsNullOrEmpty(immResult);
+            committedResult = immResult ?? string.Empty;
+            hasCommittedResult = committedResult.Length > 0;
             var rawCursor = ImmGetCompositionStringW(himc, GCS_CURSORPOS, IntPtr.Zero, 0);
             if (rawCursor == IMM_ERROR_NODATA || rawCursor == IMM_ERROR_GENERAL)
             {
-                diagnostic = $"cursor={FormatImmValue(rawCursor)}, compStringStatus={FormatImmValue(stringStatus)}, compString=\"{EscapeForLog(immComposition ?? "<null>")}\", resultStatus={FormatImmValue(resultStatus)}, hasResult={hasCommittedResult}";
+                diagnostic = $"cursor={FormatImmValue(rawCursor)}, compStringStatus={FormatImmValue(stringStatus)}, compString=\"{EscapeForLog(immComposition ?? "<null>")}\", resultStatus={FormatImmValue(resultStatus)}, resultString=\"{EscapeForLog(committedResult)}\", hasResult={hasCommittedResult}";
                 return false;
             }
 
             var normalizedCursor = rawCursor & 0xFFFF;
             var compositionMatches = immComposition == null || immComposition == unityComposition;
-            diagnostic = $"cursor={normalizedCursor}, compStringStatus={FormatImmValue(stringStatus)}, compString=\"{EscapeForLog(immComposition ?? "<null>")}\", resultStatus={FormatImmValue(resultStatus)}, hasResult={hasCommittedResult}, unityMatch={compositionMatches}";
+            diagnostic = $"cursor={normalizedCursor}, compStringStatus={FormatImmValue(stringStatus)}, compString=\"{EscapeForLog(immComposition ?? "<null>")}\", resultStatus={FormatImmValue(resultStatus)}, resultString=\"{EscapeForLog(committedResult)}\", hasResult={hasCommittedResult}, unityMatch={compositionMatches}";
             if (!compositionMatches)
                 return false;
 

--- a/ResoniteBetterIMESupport.Shared/ImeInterprocessMessage.cs
+++ b/ResoniteBetterIMESupport.Shared/ImeInterprocessMessage.cs
@@ -12,17 +12,23 @@ internal static class ImeInterprocessChannel
 internal sealed class ImeInterprocessMessage : IMemoryPackable
 {
     public string Composition = string.Empty;
+    public int CompositionCursor = -1;
+    public bool HasCommittedResult;
 
     public void Pack(ref MemoryPacker packer)
     {
         packer.Write(Composition);
+        packer.Write(CompositionCursor);
+        packer.Write(HasCommittedResult);
     }
 
     public void Unpack(ref MemoryUnpacker unpacker)
     {
         unpacker.Read(ref Composition);
+        unpacker.Read(ref CompositionCursor);
+        unpacker.Read(ref HasCommittedResult);
     }
 
     public override string ToString() =>
-        $"ImeInterprocessMessage:CompositionLength={Composition.Length}";
+        $"ImeInterprocessMessage:CompositionLength={Composition.Length},CompositionCursor={CompositionCursor},HasCommittedResult={HasCommittedResult}";
 }


### PR DESCRIPTION
## Summary

Adds Windows IMM32-backed IME composition cursor tracking for the renderer side, while keeping non-Windows and missing IMM32 environments on the existing safe fallback path.

The engine side now tracks the active composition range separately from the visual caret, draws an underline for the unconfirmed composition range, and only uses IMM32 result information as a commit-boundary signal. Committed text is still left to Resonite's normal typeDelta path.

## Root Cause

Unity composition updates did not expose enough cursor/result boundary information for Japanese IME flows. Moving the real text caret to the IMM32 cursor also interfered with Resonite's normal committed text insertion, which could place committed text at the start of the field or duplicate it.

## Validation

- `dotnet build ResoniteBetterIMESupport.sln`
- `dotnet build ResoniteBetterIMESupport.sln -c Release -p:CopyToPlugins=true`
- Manual log inspection in the Gale development profile confirmed composition cursor movement, commit-boundary handling, and no duplicate committed text in the tested flows.