### PR TITLE
[codex] Suppress F8 screen mode toggle during IME composition

### DIFF
--- a/ResoniteBetterIMESupport.Engine/EngineIMEPatch.cs
+++ b/ResoniteBetterIMESupport.Engine/EngineIMEPatch.cs
@@ -99,6 +99,14 @@ static class EngineIMEPatch
         DebugLog($"Suppressed TextEditor key from {source}: key={key}, {DebugState}");
     }
 
+    public static bool ShouldSuppressScreenModeToggleKey(Key key) =>
+        key == Key.F8 && HasCompositionRange;
+
+    public static void LogSuppressedScreenModeToggleKey(Key key, string source)
+    {
+        DebugLog($"Suppressed screen mode toggle from {source}: key={key}, {DebugState}");
+    }
+
     static void OnMessage(ImeInterprocessMessage message)
     {
         var text = _editingText;

--- a/ResoniteBetterIMESupport.Engine/Patches/ScreenModeControllerPatch.cs
+++ b/ResoniteBetterIMESupport.Engine/Patches/ScreenModeControllerPatch.cs
@@ -1,0 +1,35 @@
+using FrooxEngine;
+using HarmonyLib;
+using Renderite.Shared;
+using System.Reflection;
+using System.Reflection.Emit;
+
+namespace ResoniteBetterIMESupport.Engine.Patches;
+
+[HarmonyPatch(typeof(ScreenModeController), "OnCommonUpdate")]
+static class ScreenModeControllerPatch
+{
+    static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+    {
+        var getKeyDownMethod = AccessTools.Method(typeof(InputInterface), nameof(InputInterface.GetKeyDown));
+        var replacementMethod = AccessTools.Method(typeof(ScreenModeControllerPatch), nameof(GetKeyDown));
+
+        foreach (var instruction in instructions)
+        {
+            if (instruction.Calls(getKeyDownMethod))
+                yield return new CodeInstruction(OpCodes.Call, replacementMethod);
+            else
+                yield return instruction;
+        }
+    }
+
+    static bool GetKeyDown(InputInterface inputInterface, Key key)
+    {
+        var isDown = inputInterface.GetKeyDown(key);
+        if (!isDown || !EngineIMEPatch.ShouldSuppressScreenModeToggleKey(key))
+            return isDown;
+
+        EngineIMEPatch.LogSuppressedScreenModeToggleKey(key, "ScreenModeController.OnCommonUpdate");
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary

- Suppress Resonite's F8 VR/Screen mode toggle while an active IME composition range exists.
- Add an Engine-side debug log when F8 is actually pressed and suppressed.
- Patch `ScreenModeController.OnCommonUpdate` so only its `GetKeyDown(Key.F8)` path is affected.

## Root Cause

The existing IME key suppression only covered TextEditor `GetKeyRepeat` paths for editing keys. Resonite's VR/Screen toggle uses `InputInterface.GetKeyDown(Key.F8)` directly inside `ScreenModeController.OnCommonUpdate`, so it bypassed the previous suppression.

## Validation

- `dotnet build ResoniteBetterIMESupport.sln`
- `dotnet build ResoniteBetterIMESupport.sln -c Release -p:CopyToPlugins=true`